### PR TITLE
[trainer] feat: add use_rollout_logprobs_as_old option for flexible l…

### DIFF
--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -119,6 +119,14 @@ class RolloutCorrectionConfig(BaseConfig):
               Uses standard PPO loss with IS weight correction
             Default: False (decoupled mode)
 
+        use_rollout_logprobs_as_old (bool): Skip actor forward pass for old_log_probs.
+            - True: Set old_log_probs = rollout_log_probs (skips expensive forward pass)
+              Unlike bypass_mode, this preserves the user's loss_mode setting (gspo, vanilla, etc.)
+            - False: Compute old_log_probs via actor forward pass (standard behavior)
+            This is useful when you want to use rollout engine logprobs but still use
+            custom loss functions like GSPO. Requires rollout.calculate_log_probs=true.
+            Default: False
+
         loss_type (str): Loss function type in bypass mode (bypass_mode=True).
             - "reinforce": REINFORCE-style policy gradient with explicit IS weights
               L = -E[w * log π(a|s) * A] where w = π_current / π_rollout
@@ -168,6 +176,7 @@ class RolloutCorrectionConfig(BaseConfig):
     rollout_rs_threshold_lower: Optional[float] = None
     rollout_token_veto_threshold: Optional[float] = None
     bypass_mode: bool = False
+    use_rollout_logprobs_as_old: bool = False
     loss_type: str = "ppo_clip"
     rollout_is_batch_normalize: bool = False
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1418,12 +1418,28 @@ class RayPPOTrainer:
                             )
 
                     # Operating Mode Selection:
-                    # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)
+                    # - use_rollout_logprobs_as_old: Sets old_log_probs = rollout_log_probs, preserves user's loss_mode
+                    # - Bypass mode: Sets old_log_probs = rollout_log_probs, forces loss_mode to "bypass_mode"
                     # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
                     #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
                     rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+                    use_rollout_logprobs_as_old = (
+                        rollout_corr_config and rollout_corr_config.get("use_rollout_logprobs_as_old", False)
+                    )
                     bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
-                    if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
+
+                    if use_rollout_logprobs_as_old:
+                        # Use rollout_log_probs as old_log_probs, but preserve user's loss_mode (e.g., gspo)
+                        # Note: Rejection sampling based on old_log_probs vs rollout_log_probs would be trivial
+                        # (ratio = 1.0) so we skip it. RS during training uses π_current vs π_rollout instead.
+                        if "rollout_log_probs" not in batch.batch:
+                            raise ValueError(
+                                "use_rollout_logprobs_as_old=True requires rollout_log_probs in batch. "
+                                "Ensure rollout worker is configured with calculate_log_probs=true."
+                            )
+                        batch.batch["old_log_probs"] = batch.batch["rollout_log_probs"]
+
+                    elif bypass_recomputing_logprobs:  # Use `rollout_log_probs` with forced bypass_mode loss
                         from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
 
                         apply_bypass_mode(
@@ -1491,11 +1507,13 @@ class RayPPOTrainer:
 
                         # Compute rollout correction: IS weights, rejection sampling, and metrics
                         # Only runs in decoupled mode (computes once per batch using stable π_old)
-                        # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
+                        # In bypass mode or use_rollout_logprobs_as_old mode, this is skipped
+                        # (rejection sampling already applied above if configured)
                         if (
                             rollout_corr_config is not None
                             and "rollout_log_probs" in batch.batch
-                            and not bypass_recomputing_logprobs  # Only in decoupled mode
+                            and not bypass_recomputing_logprobs  # Skip in bypass mode
+                            and not use_rollout_logprobs_as_old  # Skip if already handled above
                         ):
                             from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
 


### PR DESCRIPTION
…oss modes

Add `use_rollout_logprobs_as_old` flag to RolloutCorrectionConfig that:
- Sets old_log_probs = rollout_log_probs (skips expensive actor forward pass)
- Preserves user's loss_mode setting (gspo, vanilla, etc.)

Unlike bypass_mode which forces loss_mode to "bypass_mode", this new option allows using any policy loss function with rollout engine logprobs.

Usage:
  algorithm.rollout_correction.use_rollout_logprobs_as_old: true
  actor_rollout_ref.actor.policy_loss.loss_mode: "gspo"
  actor_rollout_ref.rollout.calculate_log_probs: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
